### PR TITLE
Remove duplicate tag `textobj-keyvalue`.

### DIFF
--- a/doc/textobj-key-value.txt
+++ b/doc/textobj-key-value.txt
@@ -1,4 +1,4 @@
-*textobj-keyvalue* is a Vim plugin to provide text objects to select general key and value of map.
+textobj-keyvalue is a Vim plugin to provide text objects to select general key and value of map.
 
 Version: 0.1.0
 Author : vimtaku <vimtaku@gmail.com>


### PR DESCRIPTION
Fixes the error when running `helptags doc`.